### PR TITLE
Widen cypress peer dependency range

### DIFF
--- a/.changeset/silver-dolls-applaud.md
+++ b/.changeset/silver-dolls-applaud.md
@@ -1,0 +1,5 @@
+---
+'@oaknorthai/cypress-image-snapshot': patch
+---
+
+Widen cypress peer dependency range

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "rimraf": "^2.6.2"
   },
   "peerDependencies": {
-    "cypress": "^4.5.0"
+    "cypress": "^4.5.0 - 8"
   },
   "husky": {
     "hooks": {


### PR DESCRIPTION
Already tested with up to 8.3.1, so would assume anything in the 8.x range is fine.